### PR TITLE
Update file name rules

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -27,5 +27,5 @@ def generate_card(qso, positions, font, image_path, output_dir):
     draw_centered_text(draw, mode, positions["mode"], font)
     draw_centered_text(draw, rst, positions["report"], font)
 
-    out_path = os.path.join(output_dir, f"qsl_{call}_{date}.png")
+    out_path = os.path.join(output_dir, f"qsl_{call.replace('/', '_')}_{date}-{utc}.png")
     card.save(out_path)


### PR DESCRIPTION
- old filename name format; `qsl_AB1CDE_20260102.png`
- after the patch; `qsl_AB1CDE_20260102-131415.png`

this patch fixing these bugs;

1. a project doesn't merge one qsl file by callsign yet. if you have multiple qsos per one day, a generated file will be overwritten to last one.

   add time value for temporary fix

2. if callsign has `/` for specific flag such as `VK/K1ABC`, `K1ABC/P` and  `K1ABC/1`, process cannot make QSL card image. (a filename cannot has `/` char)

   forceful replace `/` to `_`